### PR TITLE
feat!: Rename JpkiAp to CryptoAp

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 
 use clap::{Parser, Subcommand};
 use dialoguer::Password;
-use jpki::ap::jpki::CertType;
+use jpki::ap::crypto::CertType;
 use jpki::ap::surface::Pin;
 use jpki::pcsc::Context;
 use tracing::metadata::LevelFilter;
@@ -132,7 +132,7 @@ fn run() -> Result<()> {
     let pcsc_card = device.connect(ctx).map_err(Error::Pcsc)?;
 
     let card = Rc::new(jpki::Card::new(Box::new(pcsc_card)));
-    let open_jpki_ap = || jpki::ap::JpkiAp::open((), Rc::clone(&card)).map_err(Error::Apdu);
+    let open_jpki_ap = || jpki::ap::CryptoAp::open((), Rc::clone(&card)).map_err(Error::Apdu);
     let open_surface_ap = || jpki::ap::SurfaceAp::open((), Rc::clone(&card)).map_err(Error::Apdu);
     let open_support_ap = || jpki::ap::SupportAp::open((), Rc::clone(&card)).map_err(Error::Apdu);
 

--- a/core/src/ap/crypto.rs
+++ b/core/src/ap/crypto.rs
@@ -1,4 +1,4 @@
-//! JPKI AP
+//! Crypto AP (formerly JPKI AP)
 
 use std::rc::Rc;
 
@@ -46,7 +46,7 @@ impl CertType {
 }
 
 /// An AP to sign or verify messages using a key-pair issued by JPKI
-pub struct JpkiAp<T, Ctx>
+pub struct CryptoAp<T, Ctx>
 where
     T: nfc::HandlerInCtx<Ctx>,
     Ctx: Copy,
@@ -54,7 +54,7 @@ where
     card: Rc<Card<T, Ctx>>,
 }
 
-impl<T, Ctx> JpkiAp<T, Ctx>
+impl<T, Ctx> CryptoAp<T, Ctx>
 where
     T: nfc::HandlerInCtx<Ctx>,
     Ctx: Copy,

--- a/core/src/ap/mod.rs
+++ b/core/src/ap/mod.rs
@@ -1,10 +1,10 @@
 //! Collection of APs that corresponds with DF (Dedicated File) in the card
 
-pub mod jpki;
+pub mod crypto;
 pub mod support;
 pub mod surface;
 
-pub use self::jpki::JpkiAp;
+pub use self::crypto::CryptoAp;
 pub use self::support::SupportAp;
 pub use self::surface::SurfaceAp;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,7 +15,7 @@ pub use card::Card;
 
 use std::rc::Rc;
 
-use ap::JpkiAp;
+use ap::CryptoAp;
 
 /// High-level API to operate with authentication certificate and the key-pair
 pub struct ClientForAuth<T, Ctx>
@@ -24,7 +24,7 @@ where
     Ctx: Copy,
 {
     #[allow(dead_code)]
-    jpki_ap: Box<JpkiAp<T, Ctx>>,
+    jpki_ap: Box<CryptoAp<T, Ctx>>,
 }
 
 impl<T, Ctx> ClientForAuth<T, Ctx>
@@ -35,7 +35,7 @@ where
     /// Initiates a client with the delegate.
     pub fn create(ctx: Ctx, delegate: Box<T>) -> Result<Self, nfc::Error> {
         Ok(Self {
-            jpki_ap: Box::new(JpkiAp::open(ctx, Rc::new(Card::new(delegate)))?),
+            jpki_ap: Box::new(CryptoAp::open(ctx, Rc::new(Card::new(delegate)))?),
         })
     }
 
@@ -53,7 +53,7 @@ where
         message: Vec<u8>,
         signature: Vec<u8>,
     ) -> Result<bool, nfc::Error> {
-        use ap::jpki::CertType;
+        use ap::crypto::CertType;
 
         Ok(digest::verify(
             self.jpki_ap.read_certificate(ctx, CertType::Auth, vec![])?,

--- a/core/src/pcsc.rs
+++ b/core/src/pcsc.rs
@@ -18,7 +18,7 @@
 //! use std::rc::Rc;
 //!
 //! use jpki::Card;
-//! use jpki::ap::JpkiAp;
+//! use jpki::ap::CryptoAp;
 //! use jpki::pcsc::Context;
 //!
 //! let ctx = Context::try_new().unwrap();
@@ -26,7 +26,7 @@
 //! let pcsc_card = device.connect(ctx).unwrap();
 //!
 //! let card = Rc::new(Card::new(Box::new(pcsc_card)));
-//! let jpki_ap = JpkiAp::open((), Rc::clone(&card)).unwrap();
+//! let jpki_ap = CryptoAp::open((), Rc::clone(&card)).unwrap();
 //! ```
 
 use std::ffi::{CStr, CString};

--- a/ffi/android/src/lib.rs
+++ b/ffi/android/src/lib.rs
@@ -169,7 +169,7 @@ pub unsafe extern "C" fn Java_jp_s6n_jpki_app_ffi_LibJpki_newCard(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_jp_s6n_jpki_app_ffi_LibJpki_newJpkiAp(
+pub unsafe extern "C" fn Java_jp_s6n_jpki_app_ffi_LibJpki_newCryptoAp(
     env: JNIEnv,
     _class: JClass,
     delegate: jlong,
@@ -184,10 +184,10 @@ pub unsafe extern "C" fn Java_jp_s6n_jpki_app_ffi_LibJpki_newJpkiAp(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_jp_s6n_jpki_app_ffi_LibJpki_jpkiApReadCertificateSign(
+pub unsafe extern "C" fn Java_jp_s6n_jpki_app_ffi_LibJpki_cryptoApReadCertificateSign(
     env: JNIEnv,
     _class: JClass,
-    jpki_ap: jlong,
+    crypto_ap: jlong,
     pin: jstring,
     ca: jboolean,
 ) -> jobject {
@@ -199,7 +199,7 @@ pub unsafe extern "C" fn Java_jp_s6n_jpki_app_ffi_LibJpki_jpkiApReadCertificateS
             _ => CertType::Sign,
         };
 
-        let ap = &mut *(jpki_ap as *mut CryptoAp<JniNfcCard, JniContext>);
+        let ap = &mut *(crypto_ap as *mut CryptoAp<JniNfcCard, JniContext>);
         let mut certificate = ap.read_certificate(ctx, ty, pin).map_err(Error::Apdu)?;
         let buffer = env
             .new_direct_byte_buffer(&mut certificate)
@@ -210,10 +210,10 @@ pub unsafe extern "C" fn Java_jp_s6n_jpki_app_ffi_LibJpki_jpkiApReadCertificateS
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_jp_s6n_jpki_app_ffi_LibJpki_jpkiApReadCertificateAuth(
+pub unsafe extern "C" fn Java_jp_s6n_jpki_app_ffi_LibJpki_cryptoApReadCertificateAuth(
     env: JNIEnv,
     _class: JClass,
-    jpki_ap: jlong,
+    crypto_ap: jlong,
     ca: jboolean,
 ) -> jobject {
     wrap!(jobject, {
@@ -224,7 +224,7 @@ pub unsafe extern "C" fn Java_jp_s6n_jpki_app_ffi_LibJpki_jpkiApReadCertificateA
             _ => CertType::Auth,
         };
 
-        let ap = &mut *(jpki_ap as *mut CryptoAp<JniNfcCard, JniContext>);
+        let ap = &mut *(crypto_ap as *mut CryptoAp<JniNfcCard, JniContext>);
         let mut certificate = ap.read_certificate(ctx, ty, pin).map_err(Error::Apdu)?;
         let buffer = env
             .new_direct_byte_buffer(&mut certificate)
@@ -235,10 +235,10 @@ pub unsafe extern "C" fn Java_jp_s6n_jpki_app_ffi_LibJpki_jpkiApReadCertificateA
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_jp_s6n_jpki_app_ffi_LibJpki_jpkiApAuth(
+pub unsafe extern "C" fn Java_jp_s6n_jpki_app_ffi_LibJpki_cryptoApAuth(
     env: JNIEnv,
     _class: JClass,
-    jpki_ap: jlong,
+    crypto_ap: jlong,
     pin: jstring,
     digest: jbyteArray,
 ) -> jobject {
@@ -247,7 +247,7 @@ pub unsafe extern "C" fn Java_jp_s6n_jpki_app_ffi_LibJpki_jpkiApAuth(
         let pin = jstring_to_bytes_vec(env, pin)?;
         let digest = env.convert_byte_array(digest).map_err(Error::Jni)?;
 
-        let ap = &mut *(jpki_ap as *mut CryptoAp<JniNfcCard, JniContext>);
+        let ap = &mut *(crypto_ap as *mut CryptoAp<JniNfcCard, JniContext>);
         let mut signature = ap.auth(ctx, pin, digest).map_err(Error::Apdu)?;
         let buffer = env
             .new_direct_byte_buffer(&mut signature)
@@ -258,12 +258,12 @@ pub unsafe extern "C" fn Java_jp_s6n_jpki_app_ffi_LibJpki_jpkiApAuth(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn Java_jp_s6n_jpki_app_ffi_LibJpki_jpkiApClose(
+pub unsafe extern "C" fn Java_jp_s6n_jpki_app_ffi_LibJpki_cryptoApClose(
     _env: JNIEnv,
     _class: JClass,
-    jpki_ap: jlong,
+    crypto_ap: jlong,
 ) {
-    let _ = Box::from_raw(jpki_ap as *mut CryptoAp<JniNfcCard, JniContext>);
+    let _ = Box::from_raw(crypto_ap as *mut CryptoAp<JniNfcCard, JniContext>);
 }
 
 #[no_mangle]

--- a/ffi/generic/src/lib.rs
+++ b/ffi/generic/src/lib.rs
@@ -1,8 +1,8 @@
 #![feature(vec_into_raw_parts)]
 #![allow(clippy::missing_safety_doc)]
 
-use jpki::ap::jpki::CertType;
-use jpki::ap::JpkiAp;
+use jpki::ap::crypto::CertType;
+use jpki::ap::CryptoAp;
 use jpki::nfc::{Command, HandlerInCtx, Response};
 use jpki::Card;
 use std::ffi::{c_char, CStr, CString};
@@ -145,18 +145,18 @@ pub unsafe extern "C" fn jpki_card_close(card: &mut Card<NfcCard, ()>) {
 #[no_mangle]
 pub unsafe extern "C" fn jpki_new_jpki_ap(
     card: *mut Card<NfcCard, ()>,
-) -> *mut JpkiAp<NfcCard, ()> {
+) -> *mut CryptoAp<NfcCard, ()> {
     let card = Rc::from_raw(card);
 
     unwrap_or(
-        JpkiAp::open((), card).map(|ap| Box::into_raw(Box::new(ap))),
+        CryptoAp::open((), card).map(|ap| Box::into_raw(Box::new(ap))),
         null_mut(),
     )
 }
 
 /// Closes the opened JPKI application.
 #[no_mangle]
-pub unsafe extern "C" fn jpki_jpki_ap_close(jpki_ap: *mut JpkiAp<NfcCard, ()>) {
+pub unsafe extern "C" fn jpki_jpki_ap_close(jpki_ap: *mut CryptoAp<NfcCard, ()>) {
     let _ = Box::from_raw(jpki_ap);
 }
 
@@ -165,7 +165,7 @@ pub unsafe extern "C" fn jpki_jpki_ap_close(jpki_ap: *mut JpkiAp<NfcCard, ()>) {
 /// If ca is true, reads a CA certificate instead.
 #[no_mangle]
 pub unsafe extern "C" fn jpki_jpki_ap_read_certificate_sign(
-    jpki_ap: *mut JpkiAp<NfcCard, ()>,
+    jpki_ap: *mut CryptoAp<NfcCard, ()>,
     pin: *const c_char,
     ca: bool,
 ) -> ByteArray {
@@ -188,7 +188,7 @@ pub unsafe extern "C" fn jpki_jpki_ap_read_certificate_sign(
 /// If ca is true, reads a CA certificate instead.
 #[no_mangle]
 pub unsafe extern "C" fn jpki_jpki_ap_read_certificate_auth(
-    jpki_ap: *mut JpkiAp<NfcCard, ()>,
+    jpki_ap: *mut CryptoAp<NfcCard, ()>,
     ca: bool,
 ) -> ByteArray {
     let ty = match ca {
@@ -208,7 +208,7 @@ pub unsafe extern "C" fn jpki_jpki_ap_read_certificate_auth(
 /// Sign the computed digest using the key-pair for user authentication.
 #[no_mangle]
 pub unsafe extern "C" fn jpki_jpki_ap_auth(
-    jpki_ap: *mut JpkiAp<NfcCard, ()>,
+    jpki_ap: *mut CryptoAp<NfcCard, ()>,
     pin: *const c_char,
     digest: ByteArray,
 ) -> ByteArray {
@@ -226,7 +226,7 @@ pub unsafe extern "C" fn jpki_jpki_ap_auth(
 /// Sign the computed digest using the key-pair for signing.
 #[no_mangle]
 pub unsafe extern "C" fn jpki_jpki_ap_sign(
-    jpki_ap: *mut JpkiAp<NfcCard, ()>,
+    jpki_ap: *mut CryptoAp<NfcCard, ()>,
     pin: *const c_char,
     digest: ByteArray,
 ) -> ByteArray {

--- a/ffi/generic/src/lib.rs
+++ b/ffi/generic/src/lib.rs
@@ -143,7 +143,7 @@ pub unsafe extern "C" fn jpki_card_close(card: &mut Card<NfcCard, ()>) {
 
 /// Opens JPKI application on the card.
 #[no_mangle]
-pub unsafe extern "C" fn jpki_new_jpki_ap(
+pub unsafe extern "C" fn jpki_new_crypto_ap(
     card: *mut Card<NfcCard, ()>,
 ) -> *mut CryptoAp<NfcCard, ()> {
     let card = Rc::from_raw(card);
@@ -156,16 +156,16 @@ pub unsafe extern "C" fn jpki_new_jpki_ap(
 
 /// Closes the opened JPKI application.
 #[no_mangle]
-pub unsafe extern "C" fn jpki_jpki_ap_close(jpki_ap: *mut CryptoAp<NfcCard, ()>) {
-    let _ = Box::from_raw(jpki_ap);
+pub unsafe extern "C" fn jpki_crypto_ap_close(crypto_ap: *mut CryptoAp<NfcCard, ()>) {
+    let _ = Box::from_raw(crypto_ap);
 }
 
 /// Reads a certificate for signing.
 /// PIN is required.
 /// If ca is true, reads a CA certificate instead.
 #[no_mangle]
-pub unsafe extern "C" fn jpki_jpki_ap_read_certificate_sign(
-    jpki_ap: *mut CryptoAp<NfcCard, ()>,
+pub unsafe extern "C" fn jpki_crypto_ap_read_certificate_sign(
+    crypto_ap: *mut CryptoAp<NfcCard, ()>,
     pin: *const c_char,
     ca: bool,
 ) -> ByteArray {
@@ -176,7 +176,7 @@ pub unsafe extern "C" fn jpki_jpki_ap_read_certificate_sign(
     };
 
     unwrap(
-        jpki_ap
+        crypto_ap
             .as_ref()
             .unwrap()
             .read_certificate((), ty, pin)
@@ -187,8 +187,8 @@ pub unsafe extern "C" fn jpki_jpki_ap_read_certificate_sign(
 /// Reads a certificate for user authentication.
 /// If ca is true, reads a CA certificate instead.
 #[no_mangle]
-pub unsafe extern "C" fn jpki_jpki_ap_read_certificate_auth(
-    jpki_ap: *mut CryptoAp<NfcCard, ()>,
+pub unsafe extern "C" fn jpki_crypto_ap_read_certificate_auth(
+    crypto_ap: *mut CryptoAp<NfcCard, ()>,
     ca: bool,
 ) -> ByteArray {
     let ty = match ca {
@@ -197,7 +197,7 @@ pub unsafe extern "C" fn jpki_jpki_ap_read_certificate_auth(
     };
 
     unwrap(
-        jpki_ap
+        crypto_ap
             .as_ref()
             .unwrap()
             .read_certificate((), ty, vec![])
@@ -207,15 +207,15 @@ pub unsafe extern "C" fn jpki_jpki_ap_read_certificate_auth(
 
 /// Sign the computed digest using the key-pair for user authentication.
 #[no_mangle]
-pub unsafe extern "C" fn jpki_jpki_ap_auth(
-    jpki_ap: *mut CryptoAp<NfcCard, ()>,
+pub unsafe extern "C" fn jpki_crypto_ap_auth(
+    crypto_ap: *mut CryptoAp<NfcCard, ()>,
     pin: *const c_char,
     digest: ByteArray,
 ) -> ByteArray {
     let pin = CStr::from_ptr(pin).to_bytes().to_vec();
 
     unwrap(
-        jpki_ap
+        crypto_ap
             .as_ref()
             .unwrap()
             .auth((), pin, digest.into())
@@ -225,15 +225,15 @@ pub unsafe extern "C" fn jpki_jpki_ap_auth(
 
 /// Sign the computed digest using the key-pair for signing.
 #[no_mangle]
-pub unsafe extern "C" fn jpki_jpki_ap_sign(
-    jpki_ap: *mut CryptoAp<NfcCard, ()>,
+pub unsafe extern "C" fn jpki_crypto_ap_sign(
+    crypto_ap: *mut CryptoAp<NfcCard, ()>,
     pin: *const c_char,
     digest: ByteArray,
 ) -> ByteArray {
     let pin = CStr::from_ptr(pin).to_bytes().to_vec();
 
     unwrap(
-        jpki_ap
+        crypto_ap
             .as_ref()
             .unwrap()
             .sign((), pin, digest.into())


### PR DESCRIPTION
The name of JPKI AP is so ambitigous for me, and in FFI bindings names such as jpki_jpki_ap made me confused. So we are going to rename it to CryptoAp as well as #25.